### PR TITLE
Create TSC.md

### DIFF
--- a/TSC.md
+++ b/TSC.md
@@ -1,0 +1,94 @@
+# Hyperledger Aries Technical Steering Committee (TSC)
+
+This file is referenced by the Hyperledger Aries Project Charter and **MUST** contain:
+
+- The list of active TSC Members
+- The duties of the TSC Members, including in those duties the process for updating those duties
+- The process to add and remove TSC Members from active status
+
+Changes to this file **MUST** be made according to the guidance in this file, and in the Hyperledger Aries Project Charter.
+
+## Active TSC Members
+
+<!-- Please keep this sorted alphabetically by github -->
+
+| GitHub ID       | Name             | Email                    | Company Affiliation |
+| --------------- | ---------------- | -------------------------| ------------------- |
+| dbluhm          | Daniel Bluhm     | daniel@indicio.tech      | Indicio PBC         |
+| swcurran        | Stephen Curran   | swcurran@cloudcompass.ca | BC Gov              |
+| TelegramSam     | Sam Curren       | telegramsam@gmail.com    | Indicio PBC         |
+| WadeBarnes      | Wade Barnes      | wade@neoterictech.ca     | BC Gov              |
+| jamshale        | Jamie Hale       |                          | BC Gov              |
+| JamesEbert      | James Ebert      |                          | Instnt              |
+
+## Emeritus TSC Members
+
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+|      |           |       |      |            |       |                     |
+
+## The Duties of a TSC Member
+
+TSC are expected to perform the following duties for the Hyperledger Aries project.
+
+- Attend the meetings of the TSC.
+  - Meetings of the TSC will generally be held during the weekly Aries Working Group calls.
+  - From time to time, special meetings of the TSC Members may be called.
+- Discuss issues about the Governance of the project, guided by the project's Charter, including the documented roles of TSC Members, Maintainers and Contributors.
+- Vote on any issues raised about the project in line with the project's Charter.
+- Discuss and vote on any issues/disputes about the projects escalated by the project's Maintainers or Contributors.
+- When moved, make changes to the project's Charter is permitted by the Charter.
+- Contribute to the Hyperledger Aries Project's Quarterly and Annual Report.
+
+The duties of the TSC Members may be updated through a PR to this file that is voted on by the TSC and merged by a Maintainer of this repository.
+Maintainers of this repository are obligated to handle PRs to this file as guided by the TSC.
+
+## Becoming a TSC Member
+
+The following steps occur in becoming a TSC member, roughly in order.
+
+- The proposed TSC Member establishes their reputation in the Hyperledger Aries Project.
+- A PR is created to update this file to add the proposed TSC to the list of active TSC Members.
+- The PR is authored by an existing TSC Member or has a comment on the PR from an existing TSC Member supporting the proposal.
+- The PR is authored by the proposed TSC Member or has a comment on the PR from the proposed TSC Member confirming their interest in being a TSC Member.
+  - The PR or comment from the proposed TSC Member must include their
+    willingness to be a long-term (more than 6 month) TSC Member.
+- Once the PR and necessary comments have been received, an approval timeframe begins.
+- The PR **MUST** be communicated on all appropriate communication channels, including relevant community calls, chat channels and mailing lists. Comments of support from the community are welcome.
+- The PR is merged and the proposed TSC Member becomes a TSC Member if either:
+  - Two weeks have passed since at least three (3) TSC Members have approved the PR or have added an comment expressing approval of the PR, OR
+  - An absolute majority of TSC Members have approved the PR or have added an comment expressing approval of the PR.
+- If the PR does not get the requisite PR approvals or comments expressing approval of the PR, it may be closed.
+
+TSC membership itself does not confer repository Maintainer status -- that is a separate process.
+Typically, TSC members will also be Maintainers, but the processes are independent of one another.
+
+## Removing TSC Members
+
+Being a TSC Member is not a status symbol or a title to be carried
+indefinitely. It will occasionally be necessary and appropriate to move a
+TSC Member to emeritus status. This can occur in the following situations:
+
+- Resignation of a TSC Member.
+- Violation of the Code of Conduct warranting removal.
+- Inactivity.
+  - A general measure of inactivity will be an extended period of not showing up to TSC Meetings, or participating in TSC discussions at Meetings or in TSC online forums.
+  - Reasonable exceptions to inactivity will be granted for known long term
+    leave such as parental leave and medical leave.
+- Other circumstances at the discretion of the other TSC Members.
+
+The process to move a TSC Member from active to emeritus status is comparable to the process for adding a TSC Member, outlined above. In the case of voluntary
+resignation, the Pull Request can be merged following a TSC Member PR approval or approval comment. If the removal is for any other reason, the following steps **SHOULD** be followed:
+
+- A PR is created to update this file to move the TSC Member to the list of emeritus TSC Members.
+- The PR is authored by, or has a comment supporting the proposal from, an existing TSC Member or Hyperledger GitHub organization administrator.
+- Once the PR and necessary comments have been received, the approval timeframe begins.
+- The PR **MAY** be communicated on appropriate communication channels, including relevant community calls, chat channels and mailing lists.
+- The PR is merged and the TSC Members transitions to TSC Members emeritus if:
+  - The PR is approved or an approval comment added by the TSC Members to be transitioned, OR
+  - Two weeks have passed since at least three (3) TSC Member PR approvals or approval comments have been recorded, OR
+  - An absolute majority of TSC Members have approved the PR or added an approval comment.
+- If the PR does not get the requisite PR approvals, it may be closed.
+
+Returning to active status from emeritus status uses the same steps as adding a
+new TSC Member.


### PR DESCRIPTION
Defines the TSC.md file referenced in the Aries Project Charter. I've proposed aligned changes to the Aries Project Charter.  Still to come is a change to the maintainers file that reflects the new roles of the access_control.yaml file in listing maintainers.

@TelegramSam -- please raise this issue at the Aries Working Group call this week. We are a little late in getting the Charter formalized.
@cjhowland -- could you please raise this at the next Indy Contributor Call as a model for Indy and AnonCreds, as the model seems appropriate for both projects?
@ryjones -- please flag other members of the Hyperledger staff that need to be aware of this approach.