### PR TITLE
Add proper security document and document team

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,23 +1,172 @@
-# Hyperledger Security Policy
+# Hyperledger Aries Security Policy
 
-## Reporting a Security Bug
+[Hyperledger security vulnerability disclosure policy]: /governing-documents/security.md
 
-If you think you have discovered a security issue in any of the Hyperledger
-projects, we'd love to hear from you. We will take all security bugs
-seriously and if confirmed upon investigation we will patch it within a
-reasonable amount of time and release a public security bulletin discussing
-the impact and credit the discoverer.
+## About this document
 
-There are two ways to report a security bug. The easiest is to email a
-description of the flaw and any related information (e.g. reproduction
-steps, version) to
-[security at hyperledger dot org](mailto:security@hyperledger.org).
+This document defines how security vulnerability reporting is handled in the
+Hyperledger Aries project. The approach aligns with the [Hyperledger
+Foundation's Security Vulnerability Reporting
+policy](https://toc.hyperledger.org/governing-documents/security.html). Please
+review that document to understand the basis of the security reporting for
+Hyperledger Aries.
 
-The other way is to file a confidential security bug in our
-[JIRA bug tracking system](https://jira.hyperledger.org).
-Be sure to set the “Security Level” to “Security issue”.
+The Hyperledger Security Vulnerability policy borrows heavily from the
+recommendations of the OpenSSF Vulnerability Disclosure working group. For
+up-to-date information on the latest recommendations related to vulnerability
+disclosures, please visit the [GitHub of that working
+group](https://github.com/ossf/wg-vulnerability-disclosures).
 
-The process by which the Hyperledger Security Team handles security bugs
-is documented further in our
-[Defect Response](https://wiki.hyperledger.org/display/HYP/Defect+Response)
-page on our [wiki](https://wiki.hyperledger.org).
+If you are already familiar with the security policies of Hyperledger Aries, and
+ready to report a vulnerability, please jump to [Report
+Intakes](#report-intakes).
+
+## Outline
+
+This document has the following sections:
+
+- [Hyperledger Aries Security Policy](#hyperledger-Aries-security-policy)
+  - [About this document](#about-this-document)
+  - [Outline](#outline)
+  - [What Is a Vulnerability Disclosure Policy?](#what-is-a-vulnerability-disclosure-policy)
+  - [Security Team](#security-team)
+  - [Discussion Forums](#discussion-forums)
+  - [Report Intakes](#report-intakes)
+  - [CNA/CVE Reporting](#cnacve-reporting)
+  - [Embargo List](#embargo-list)
+  - [(GitHub) Security Advisories](#github-security-advisories)
+  - [Private Patch Deployment Infrastructure](#private-patch-deployment-infrastructure)
+
+## What Is a Vulnerability Disclosure Policy?
+
+No piece of software is perfect. All software (at least, all software of a
+certain size and complexity) has bugs. In open source development, members of
+the community or the public find bugs and report them to the project. A
+vulnerability disclosure policy explains how this process functions from the
+perspective of the project.
+
+This vulnerability disclosure policy explains the rules and guidelines for
+Hyperledger Aries. It is intended to act as both a reference for
+outsiders–including both bug reporters and those looking for information on the
+project's security practices–as well as a set of rules that maintainers and
+contributors have agreed to follow.
+
+## Security Team
+
+The current Hyperledger Aries security team is:
+
+| Name           | Email ID                 | Discord ID  | Area/Specialty       |
+| -------------- | ------------------------ | ----------- | -------------------- |
+| Stephen Curran | swcurran@cloudcompass.ca | swcurran    |                      |
+| Wade Barnes    | wade@neoterictech.ca     | WadeBarnes  | Security, Operations |
+| Sam Curren     | sam@indicio.tech         | TelegramSam | Security             |
+| Daniel Bluhm   | daniel@indicio.tech      | dbluhm      | Security             |
+
+The security team for Hyperledger Aries must include at least three Aries
+Maintainers that agree to carry out the following duties and responsibilities.
+Members are added and removed from the team via approved Pull Requests to this
+repository. For additional background into the role of the security team, see
+the [People Infrastructure] section of the Hyperledger Security Policy.
+
+[People Infrastructure]: https://toc.hyperledger.org/governing-documents/security.html#people-infrastructure
+
+**Responsibilities:**
+
+1. Acknowledge the receipt of vulnerability reports to the reporter within 2
+   business days.
+
+2. Assess the issue. Engage with the reporter to ask any outstanding questions
+about the report and how to reproduce it. If the report was received by email
+and may be a security vulnerability, open a GitHub Security Advisory on the
+repository to manage the report. If the report is not considered a
+vulnerability, then the reporter should be informed and this process can be
+halted. If the report is a regular bug (but not a security vulnerability), the
+reporter should be informed (if necessary) of the regular process for reporting
+issues.
+
+1. Some issues may require more time and resources to correct. If a particular
+report is complex, discuss an embargo period with the reporter during which
+time the report will not be publicly disclosed. The embargo period should be
+negotiated with the reporter and must not be longer than 90 days.
+
+1. If necessary, create a private patch development infrastructure for the issue
+   by emailing the [Hyperledger Community Architects].
+
+[Hyperledger Community Architects]: mailto:community-architects@hyperledger.org
+
+5. Request a CVE for the issue (see the [CNA/CVE Reporting](#cnacve-reporting)
+   section).
+
+6. Decide a date for the public release of the vulnerability report, the date
+   the embargo period ends.
+
+7. If applicable, notify members of the embargo list of the vulnerability,
+upcoming patch and release, as described above.
+
+8. Publish a new (software) release in which the vulnerability is addressed.
+
+9. Publicly disclose the issue within 48 hours after the release via a
+GitHub security advisory (see the [(GitHub) Security
+Advisories](#github-security-advisories) section for details).
+
+## Discussion Forums
+
+Discussions about each reported vulnerability should be carried out in the
+private GitHub security advisory about the vulnerability. If necessary, a private
+channel specific to the issue may be created on the Hyperledger Discord server
+with invited participants added to the discussion.
+
+## Report Intakes
+
+Hyperledger Aries has the following ways to submit security
+vulnerabilities. While the security team members will do their best to
+respond to bugs disclosed in all possible ways, it is encouraged for bug
+finders to report through the following approved channels:
+
+- Email the [Hyperledger Foundation security
+list](mailto:security@lists.hyperledger.org): To report a security issue, please
+send an email with the name of the project/repository, a description of the issue, the
+steps you took to create the issue, affected versions, and if known,
+mitigations. If in triaging the email, the security team determines the issue may be
+a security vulnerability, a [GitHub security vulnerability report] will be
+opened.
+- Open a [GitHub security vulnerability report]: Open a draft security advisory
+on the "Security" tab of this GitHub repository. See [GitHub Security
+Advisories](#github-security-advisories) to learn more about the security
+infrastructure in GitHub.
+
+[GitHub security vulnerability report]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
+
+## CNA/CVE Reporting
+
+Hyperledger Aries maintains a list of **Common Vulnerabilities and Exposures
+(CVE)** and uses GitHub as its **CVE numbering authority (CNA)** for issuing
+CVEs.
+
+## Embargo List
+
+Hyperledger Aries does **NOT** currently maintain a private embargo list.
+
+If you wish to be added to the embargo list, please email the [Hyperledger
+Foundation security mailing list](mailto:security@lists.hyperledger.org),
+including the project name (Hyperledger Aries) and reason for being added
+to the embargo list. Requests will be assessed by the Hyperledger Aries
+security team in conjunction with the appropriate Hyperledger Staff, and a
+decision will be made to accommodate or not the request.
+
+For more information about embargo lists, please see the [Embargo List section
+of the Hyperledger Security
+Policy](https://toc.hyperledger.org/governing-documents/security.html#embargo-list).
+
+## (GitHub) Security Advisories
+
+Hyperledger Aries uses GitHub Security Advisories to manage the public
+disclosure of security vulnerabilities.
+
+## Private Patch Deployment Infrastructure
+
+In creating patches and new releases that address security vulnerabilities,
+Hyperledger Aries **MAY** use the private development features of GitHub for
+security vulnerabilities. GitHub has [extensive
+documentation](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories)
+about these features.


### PR DESCRIPTION
Adds security document in the form defined by the Hyperledger TOC, including a proposed security team.
